### PR TITLE
feat: Implement infinite scroll pagination on repository list

### DIFF
--- a/SwiftRepos/SwiftRepos/Features/PullRequestList/PullRequestListViewController.swift
+++ b/SwiftRepos/SwiftRepos/Features/PullRequestList/PullRequestListViewController.swift
@@ -93,7 +93,9 @@ final class PullRequestListViewController: UIViewController {
 
         viewModel.state
             .map { $0.pullRequests }
-            .drive(tableView.rx.items(cellIdentifier: PullRequestCell.reuseID, cellType: PullRequestCell.self)) { (row, pullRequest, cell) in
+            .drive(tableView.rx.items(
+                cellIdentifier: PullRequestCell.reuseID,
+                cellType: PullRequestCell.self)) { (row, pullRequest, cell) in
                 cell.configure(with: pullRequest)
             }
             .disposed(by: disposeBag)

--- a/SwiftRepos/SwiftRepos/Features/RepositoryList/RepositoryListIntent.swift
+++ b/SwiftRepos/SwiftRepos/Features/RepositoryList/RepositoryListIntent.swift
@@ -2,4 +2,5 @@ enum RepositoryListIntent {
     
     case viewDidAppear
     case repositorySelected(Repository)
+    case reachedEndOfList
 }

--- a/SwiftRepos/SwiftRepos/Features/RepositoryList/RepositoryListState.swift
+++ b/SwiftRepos/SwiftRepos/Features/RepositoryList/RepositoryListState.swift
@@ -1,8 +1,17 @@
 struct RepositoryListState {
-    
-    var isLoading: Bool
+    var isLoadingFirstPage: Bool
     var repositories: [Repository]
     var error: String?
+    var currentPage: Int
+    var isFetchingNextPage: Bool
+    var canLoadMorePages: Bool
 
-    static let initial = RepositoryListState(isLoading: false, repositories: [], error: nil)
+    static let initial = RepositoryListState(
+        isLoadingFirstPage: false,
+        repositories: [],
+        error: nil,
+        currentPage: 1,
+        isFetchingNextPage: false,
+        canLoadMorePages: true
+    )
 }

--- a/SwiftRepos/SwiftRepos/Features/RepositoryList/RepositoryListViewModel.swift
+++ b/SwiftRepos/SwiftRepos/Features/RepositoryList/RepositoryListViewModel.swift
@@ -6,8 +6,23 @@ enum RepositoryListNavigation {
     case showPullRequests(for: Repository)
 }
 
-final class RepositoryListViewModel: RepositoryListViewModelProtocol {
+enum RepositoryListAction {
+    case fetchFirstPage
+    case fetchNextPage(page: Int)
+}
+
+enum RepositoryListResult {
+    case setLoadingFirstPage(Bool)
+    case fetchFirstPageSuccess(repos: [Repository])
+    case fetchFirstPageFailure(error: Error)
     
+    case setLoadingNextPage(Bool)
+    case fetchNextPageSuccess(repos: [Repository], page: Int)
+    case fetchNextPageFailure(error: Error)
+}
+
+final class RepositoryListViewModel: RepositoryListViewModelProtocol {
+
     let intent = PublishRelay<RepositoryListIntent>()
     let state: Driver<RepositoryListState>
     let navigation: Signal<RepositoryListNavigation>
@@ -15,35 +30,105 @@ final class RepositoryListViewModel: RepositoryListViewModelProtocol {
     private let disposeBag = DisposeBag()
 
     init(apiService: APIServiceProtocol) {
-        
         let stateRelay = BehaviorRelay<RepositoryListState>(value: .initial)
         let navigationRelay = PublishRelay<RepositoryListNavigation>()
         
         self.state = stateRelay.asDriver()
         self.navigation = navigationRelay.asSignal()
 
-        intent
-            .subscribe(onNext: { intent in
+        let action = intent
+            .withLatestFrom(stateRelay) { intent, state in
+                (intent, state)
+            }
+            .flatMapLatest { intent, state -> Observable<RepositoryListAction> in
                 switch intent {
                 case .viewDidAppear:
-                    guard stateRelay.value.repositories.isEmpty else { return }
-
-                    stateRelay.accept(RepositoryListState(isLoading: true, repositories: [], error: nil))
-
-                    Task {
-                        do {
-                            let repos = try await apiService.fetchRepositories(page: 1)
-
-                            stateRelay.accept(RepositoryListState(isLoading: false, repositories: repos, error: nil))
-                        } catch {
-                            stateRelay.accept(RepositoryListState(isLoading: false, repositories: [], error: error.localizedDescription))
-                        }
-                    }
+                    guard state.repositories.isEmpty else { return .empty() }
+                    return .just(.fetchFirstPage)
+                    
+                case .reachedEndOfList:
+                    guard !state.isFetchingNextPage && state.canLoadMorePages else { return .empty() }
+                    return .just(.fetchNextPage(page: state.currentPage + 1))
                     
                 case .repositorySelected(let repository):
                     navigationRelay.accept(.showPullRequests(for: repository))
+                    return .empty()
                 }
-            })
+            }
+            .share()
+
+        let result = action
+            .flatMapLatest { action -> Observable<RepositoryListResult> in
+                switch action {
+                case .fetchFirstPage:
+                    return Observable.create { observer in
+                        observer.onNext(.setLoadingFirstPage(true))
+                        Task {
+                            do {
+                                let repos = try await apiService.fetchRepositories(page: 1)
+                                observer.onNext(.fetchFirstPageSuccess(repos: repos))
+                                observer.onCompleted()
+                            } catch {
+                                observer.onNext(.fetchFirstPageFailure(error: error))
+                                observer.onCompleted()
+                            }
+                        }
+                        return Disposables.create()
+                    }
+                    
+                case .fetchNextPage(let page):
+                    return Observable.create { observer in
+                        observer.onNext(.setLoadingNextPage(true))
+                        Task {
+                            do {
+                                let repos = try await apiService.fetchRepositories(page: page)
+                                observer.onNext(.fetchNextPageSuccess(repos: repos, page: page))
+                                observer.onCompleted()
+                            } catch {
+                                observer.onNext(.fetchNextPageFailure(error: error))
+                                observer.onCompleted()
+                            }
+                        }
+                        return Disposables.create()
+                    }
+                }
+            }
+
+        result
+            .scan(RepositoryListState.initial) { previousState, result -> RepositoryListState in
+                var newState = previousState
+                
+                switch result {
+                case .setLoadingFirstPage(let isLoading):
+                    newState.isLoadingFirstPage = isLoading
+                    newState.error = nil
+                    
+                case .fetchFirstPageSuccess(let repos):
+                    newState.isLoadingFirstPage = false
+                    newState.repositories = repos
+                    
+                case .fetchFirstPageFailure(let error):
+                    newState.isLoadingFirstPage = false
+                    newState.error = error.localizedDescription
+
+                case .setLoadingNextPage(let isLoading):
+                    newState.isFetchingNextPage = isLoading
+                    
+                case .fetchNextPageSuccess(let repos, let page):
+                    newState.isFetchingNextPage = false
+                    newState.repositories.append(contentsOf: repos)
+                    newState.currentPage = page
+                    newState.canLoadMorePages = !repos.isEmpty
+                    
+                case .fetchNextPageFailure(let error):
+                    newState.isFetchingNextPage = false
+                    newState.error = error.localizedDescription
+                }
+                
+                return newState
+            }
+            .startWith(.initial)
+            .bind(to: stateRelay)
             .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
This Pull Request implements the pagination feature (infinite scroll) on the repository list screen. Instead of loading all API results at once, the application now loads the first page and automatically fetches subsequent pages as the user scrolls, significantly improving initial performance and user experience.

## What was changed?
### MVI Architecture
- The `RepositoryListState` was extended to manage the pagination state (currentPage, isFetchingNextPage, canLoadMorePages).
- Added the `.reachedEndOfList` intent.
- The `RepositoryListViewModel` was refactored to a more robust reactive logic that handles the sequential loading of pages and appends the new results to the existing list.

### User Interface (UI)
- The `RepositoryListViewController` now detects the end of the scroll by observing the `contentOffset` property of the UITableView for a more robust and efficient detection.
- An activity indicator (`UIActivityIndicatorView`) is dynamically added to the UITableView's footer and is displayed only while loading a new page, without causing layout issues or "ghost spaces".

### How to test?
1. Run the application.
2. Scroll down the list of repositories.
3. Observe that as you approach the end of the list, a loading indicator briefly appears in the footer.
4. Verify that new repositories are added to the end of the list and the scroll remains fluid.

### Feature Video
https://github.com/user-attachments/assets/e9c7dcd7-99c6-46d9-97ca-0158c61fa983