### PR TITLE
feat: Improve Error Handling for Pagination

### DIFF
--- a/SwiftRepos/Core/Extensions/String+Localization.swift
+++ b/SwiftRepos/Core/Extensions/String+Localization.swift
@@ -9,6 +9,7 @@ extension String {
     }
 
     struct LocalizedKeys {
+        
         // MARK: Screen Titles
         static let repositoryListTitle = "repository_list_title".localized()
         static let pullRequestDetailsTitle = "pull_request_details_title".localized()
@@ -23,6 +24,16 @@ extension String {
         
         static func statsHeader(open: Int, closed: Int) -> String {
             return String(format: NSLocalizedString("stats_header_format", comment: ""), open, closed)
+        }
+        
+        // MARK: Error Messages
+        static let errorInvalidURL = "error_invalid_url".localized()
+        static let errorDecoding = "error_decoding".localized()
+        static func errorRequestFailed(description: String) -> String {
+            return String(format: NSLocalizedString("error_request_failed_format", comment: ""), description)
+        }
+        static func errorUnexpectedStatus(code: Int) -> String {
+            return String(format: NSLocalizedString("error_unexpected_status_format", comment: ""), code)
         }
     }
 }

--- a/SwiftRepos/Core/Network/APIError.swift
+++ b/SwiftRepos/Core/Network/APIError.swift
@@ -9,13 +9,13 @@ enum APIError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidURL:
-            return "A URL fornecida é inválida."
+            return String.LocalizedKeys.errorInvalidURL
         case .requestFailed(let error):
-            return "A requisição falhou: \(error.localizedDescription)"
-        case .decodingError(let error):
-            return "Erro ao decodificar a resposta: \(error.localizedDescription)"
+            return String.LocalizedKeys.errorRequestFailed(description: error.localizedDescription)
+        case .decodingError:
+            return String.LocalizedKeys.errorDecoding
         case .unexpectedStatusCode(let statusCode):
-            return "A API retornou um status inesperado: \(statusCode)"
+            return String.LocalizedKeys.errorUnexpectedStatus(code: statusCode)
         }
     }
 }

--- a/SwiftRepos/Features/RepositoryList/Models/RepositoryListState.swift
+++ b/SwiftRepos/Features/RepositoryList/Models/RepositoryListState.swift
@@ -6,6 +6,7 @@ struct RepositoryListState {
     var currentPage: Int
     var isFetchingNextPage: Bool
     var canLoadMorePages: Bool
+    var paginationError: String?
 
     static let initial = RepositoryListState(
         isLoadingFirstPage: false,
@@ -13,6 +14,7 @@ struct RepositoryListState {
         error: nil,
         currentPage: 1,
         isFetchingNextPage: false,
-        canLoadMorePages: true
+        canLoadMorePages: true,
+        paginationError: nil
     )
 }

--- a/SwiftRepos/Features/RepositoryList/RepositoryListReducer.swift
+++ b/SwiftRepos/Features/RepositoryList/RepositoryListReducer.swift
@@ -11,6 +11,9 @@ func repositoryListReducer(
     dependency: APIServiceProtocol
 ) -> Effect<RepositoryListAction>? {
     
+    state.error = nil
+    state.paginationError = nil
+    
     switch action {
     case .viewDidAppear:
         guard state.repositories.isEmpty else { return nil }
@@ -68,6 +71,7 @@ func repositoryListReducer(
         
     case .nextPageResponse(.failure(let error)):
         state.isFetchingNextPage = false
+        state.paginationError = error.localizedDescription
         return nil
     }
 }

--- a/SwiftRepos/Resources/Localizable.xcstrings
+++ b/SwiftRepos/Resources/Localizable.xcstrings
@@ -12,6 +12,50 @@
         }
       }
     },
+    "error_decoding" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to decode the server response."
+          }
+        }
+      }
+    },
+    "error_invalid_url" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The provided URL is invalid."
+          }
+        }
+      }
+    },
+    "error_request_failed_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The request failed: %@"
+          }
+        }
+      }
+    },
+    "error_unexpected_status_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The API returned an unexpected status: %d"
+          }
+        }
+      }
+    },
     "pull_request_details_title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SwiftReposTests/RepositoryListReducerTests.swift
+++ b/SwiftReposTests/RepositoryListReducerTests.swift
@@ -89,4 +89,22 @@ final class RepositoryListReducerTests: XCTestCase {
         XCTAssertTrue(state.isFetchingNextPage, "isFetchingNextPage should be true")
         XCTAssertNotNil(effect, "An effect to fetch the next page should be returned")
     }
+    
+    // Tests if, after a pagination failure, the state is updated with a pagination error.
+    func test_nextPageResponse_withFailure_shouldUpdateStateWithPaginationError() {
+        // Given
+        var state = RepositoryListState.initial
+        state.isFetchingNextPage = true
+        let error = MockAPIService.MockError.networkError
+        let action = RepositoryListAction.nextPageResponse(.failure(error))
+        
+        // When
+        let effect = repositoryListReducer(state: &state, action: action, dependency: mockApiService)
+        
+        // Then
+        XCTAssertFalse(state.isFetchingNextPage, "isFetchingNextPage should be false after a failure response")
+        XCTAssertNotNil(state.paginationError, "A paginationError message should be set in the state")
+        XCTAssertNil(state.error, "The main screen error should be nil")
+        XCTAssertNil(effect, "No new effect should be returned after a failure response")
+    }
 }


### PR DESCRIPTION
This Pull Request improves the user experience by implementing a more robust and subtle error handling mechanism for the pagination feature on the repository list screen.

Instead of failing silently or blocking the UI, pagination errors are now communicated to the user via a non-intrusive, auto-dismissing toast notification. Additionally, all error messages have been centralized and prepared for localization.

### What was changed?

- **Pagination Error Toast**: A custom toast view was added to the `RepositoryListViewController` to display errors that occur when fetching subsequent pages.
- **Auto-Dismiss Logic**: The toast notification automatically disappears after a few seconds.
- **State Management**: The `RepositoryListState` was updated with a new `paginationError` property to differentiate between initial load errors.
- **Localization**: All user-facing error messages from the `APIError` enum were moved into the `Localizable.xcstrings` catalog and are now accessed via the type-safe `String.LocalizedKeys` extension.
- **Unit Test**: A new unit test case was included to `RepositoryListReducerTests`, that verifies that when a `nextPageResponse` with a failure is received, the state is correctly updated with a `paginationError` and the main screen `error` remains nil.

### How to test?

1.  To simulate a pagination error, temporarily modify the `APIService` to throw an error for `page > 1`.
2.  Run the application. The first page should load correctly.
3.  Scroll to the bottom of the list to trigger pagination.
4.  Verify that a red toast notification appears at the bottom of the screen with the corresponding error message.
5.  Verify that the toast automatically disappears after a few seconds.

### Feature Video

https://github.com/user-attachments/assets/b5f6d8dd-378d-4192-99f3-a3d3cd53497e
